### PR TITLE
Fix for systems which expect PIE code by default

### DIFF
--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
 #define VARIABLE_NUM_POINTER  0
 /** commandline used for linking */
 #define LINK_COMMAND          "cc a.s"
+#define LINK_COMMAND_NOPIE    "cc a.s -no-pie 2> /dev/null"
 
 static FILE *input;
 
@@ -383,7 +384,10 @@ int main(int argc, char **argv)
 	be_main(out, argv[1]);
 	fclose(out);
 
-	system(LINK_COMMAND);
+	int err = system(LINK_COMMAND_NOPIE);
+	if (err != EXIT_SUCCESS) {
+		err = system(LINK_COMMAND);
+	}
 
-	return 0;
+	return err;
 }


### PR DESCRIPTION
Newer systems expect PIE code by default. We explicitly specify the
-no-pie option to fix this.
However, older versions of the gnu linker do not support this option.
Therefore we retry linking without the -no-pie option, if linking
including the option failed.